### PR TITLE
fixed warning on PropTypes with React >= 15.5.0

### DIFF
--- a/src/modules/Dropdown/Dropdown.js
+++ b/src/modules/Dropdown/Dropdown.js
@@ -65,7 +65,7 @@ export default class Dropdown extends Component {
       customPropTypes.disallow(['options', 'selection']),
       customPropTypes.givenProps(
         { children: PropTypes.any.isRequired },
-        React.PropTypes.element.isRequired,
+        PropTypes.element.isRequired,
       ),
     ]),
 


### PR DESCRIPTION
Seems that the commit 2dc8a47142c2d948fe7ab827bf87903a9fb93c9b doesn't update a PropTypes, so it also has a warning when in developing.